### PR TITLE
fix: prevent mobile background overflow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,3 +1,8 @@
+/* 全局设置盒模型，避免移动端宽度溢出 */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
 /* 语言切换按钮 */
 .lang-switch-btn {
     position: absolute;


### PR DESCRIPTION
## Summary
- use border-box sizing globally to avoid mobile background overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c599a36ba48325a7025b1b1b539daf