### PR TITLE
fix: prevent mobile background overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | `CNAME`：自定义域名配置（用于 GitHub Pages 或类似平台）。 | `CNAME`: Custom domain config (for GitHub Pages or similar). |
 | `robots.txt`：搜索引擎爬虫规则。 | `robots.txt`: Search engine crawler rules. |
 | `sitemap.xml`：网站地图，便于搜索引擎收录。 | `sitemap.xml`: Sitemap for search engine indexing. |
+| 修复：通过全局设置 `box-sizing: border-box`，解决移动端背景溢出问题。 | Fix: globally set `box-sizing: border-box` to prevent mobile background overflow. |
 
 ## 特色特效 / Special Effects
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,3 +1,8 @@
+/* 全局设置盒模型，避免移动端宽度溢出 */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
 /* 语言切换按钮 */
 .lang-switch-btn {
     position: absolute;


### PR DESCRIPTION
## Summary
- use border-box sizing globally to avoid mobile background overflow
- document mobile background overflow fix in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c599a36ba48325a7025b1b1b539daf